### PR TITLE
Use natsort package for sorting project version numbers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ADD ./tox.ini ./tox.ini
 RUN pip install flask
 RUN pip install six
 RUN pip install conf
+RUN pip install natsort
 
 ENV HTD_HOST "0.0.0.0"
 ENV HTD_PORT 5000

--- a/setup.py
+++ b/setup.py
@@ -11,5 +11,7 @@ setup(
     install_requires=[
         'Flask',
         'six',
+        'conf',
+        'natsort',
     ],
 )

--- a/tests/test_filekeeper.py
+++ b/tests/test_filekeeper.py
@@ -4,6 +4,7 @@ import random
 import shutil
 import tempfile
 import unittest
+import natsort
 
 from hostthedocs import filekeeper as fk
 from tests import DOCFILESDIR, THISDIR
@@ -103,12 +104,15 @@ class DeleteFilesTests(unittest.TestCase):
 class SortByVersionTests(unittest.TestCase):
 
     def test_sorts(self):
-        vers = ['0.9', '1.0', '1.0.0', '1.0.1', '1.1', '1.1.0', '1.1.1', '7.8.9']
+        vers = [
+            '1.1', '1.2alpha', '1.2beta1', '1.2beta2',
+            '1.2rc1', '1.2', '1.2.1', '1.3'
+        ]
         vers = [dict(version=v) for v in vers]
         randvers = list(vers)
         random.shuffle(randvers)
         self.assertNotEqual(vers, randvers)
-        randvers.sort(key=fk.sort_by_version)
+        randvers = natsort.natsorted(randvers, key=fk.sort_by_version)
         self.assertEqual(vers, randvers)
 
     def test_sorts_with_nonnumeric(self):


### PR DESCRIPTION
The usage of natsort allows the compatibility with both numbers and characters in the version string.
See http://natsort.readthedocs.io/en/stable/examples.html#sorting-with-alpha-beta-and-release-candidates

natsort has been added to the requirements in both the setup.py and the Dockerfile