### PR TITLE
Replace old versions with dropdown menu

### DIFF
--- a/hostthedocs/templates/index.html
+++ b/hostthedocs/templates/index.html
@@ -1,6 +1,14 @@
 {% extends 'base.html' %}
 
 {% block body %}
+    <script type="text/javascript">
+        function gotodocs(obj)
+        {
+         var selectedValue = obj.options[obj.selectedIndex].value;
+         window.location.href = selectedValue;
+        }
+    </script>
+
     <div class="container">
 
         <div class="jumbotron">
@@ -25,11 +33,16 @@
                             <p><a href="{{ version.link }}">
                                 {% if version.version == 'latest' %}
                                     Latest
-                                {% else %}
-                                    Version {{ version.version }}
                                 {% endif %}
                             </a></p>
                         {% endfor %}
+                        <select name="{{ project.name }}" onchange="gotodocs(this);">
+                        {% for version in project.versions %}
+                            {% if version.version != 'latest' %}
+                                <option value="{{ version.link }}">{{ version.version }}</option>
+                            {% endif %}
+                        {% endfor %}
+                        </select>
                         <!--<p><a href="#" class="btn btn-primary">Buy Now!</a>  <a href="#" class="btn btn-default">More Info</a>-->
                         <!--</p>-->
                     </div>


### PR DESCRIPTION
This MR puts 'Latest' at the top of the links and replaces all other versions with a dropdown menu.

+ It's a bit of a hack but it'll do.

## Old:
![image](https://cloud.githubusercontent.com/assets/5386897/26475949/001b1be8-4170-11e7-808a-9136955422fa.png)


## New:
![image](https://cloud.githubusercontent.com/assets/5386897/26475877/53c21072-416f-11e7-91cb-f82f89b86c5a.png)
