### PR TITLE
Implement url_name parameter (Resolves #6)

### DIFF
--- a/hostthedocs/filekeeper.py
+++ b/hostthedocs/filekeeper.py
@@ -87,7 +87,12 @@ def parse_docfiles(docfiles_dir, link_root):
 
 
 def unpack_project(uploaded_file, proj_metadata, docfiles_dir):
-    projdir = os.path.join(docfiles_dir, proj_metadata['name'])
+    # Try to join docfiles with url_name key which may exist
+    try:
+        projdir = os.path.join(docfiles_dir, proj_metadata['url_name'])
+    # If nonexistent, just go by project name
+    except KeyError:
+        projdir = os.path.join(docfiles_dir, proj_metadata['name'])
     verdir = os.path.join(projdir, proj_metadata['version'])
 
     if not os.path.isdir(verdir):


### PR DESCRIPTION
This adds a few lines of code which should handle a url_name parameter correctly. projdir will use url_name if that parameter exists in request and name by default if it doesn't.