### PR TITLE
Index should show current versions in dropdown

### DIFF
--- a/hostthedocs/templates/index.html
+++ b/hostthedocs/templates/index.html
@@ -41,7 +41,7 @@
                         <select name="{{ project.name }}" onchange="gotodocs(this);"
                                 class="btn btn-success dropdown-toggle" type="button"
                                 role="menu" aria-haspopup="true" aria-expanded="false">
-                        {% for version in project.versions %}
+                        {% for version in project.versions | reverse %}
                             {% if version.version != 'latest' %}
                                 <option value="{{ version.link }}">{{ version.version }}</option>
                             {% endif %}


### PR DESCRIPTION
The most recent available version should be the default in the dropdown menus, so that the current version is immediately visible when visiting the  page. 