### PR TITLE
enable path converter for latest redirects

### DIFF
--- a/hostthedocs/__init__.py
+++ b/hostthedocs/__init__.py
@@ -52,7 +52,7 @@ def latest_root(project):
     return latest(project, '')
 
 
-@app.route('/<project>/latest/<path>')
+@app.route('/<project>/latest/<path:path>')
 def latest(project, path):
     parsed_docfiles = parse_docfiles(getconfig.docfiles_dir, getconfig.docfiles_link_root)
     proj_for_name = dict((p['name'], p) for p in parsed_docfiles)

--- a/tests/test_hostthedocs.py
+++ b/tests/test_hostthedocs.py
@@ -64,6 +64,9 @@ class LatestTests(Base):
     def test_latest_certainfile(self):
             self.assert_redirect('/Project2/latest/somefile.html', 302, '/linkroot/Project2/2.0.3/somefile.html')
 
+    def test_latest_nestedfile(self):
+            self.assert_redirect('/Project2/latest/foo/bar/somefile.html', 302, '/linkroot/Project2/2.0.3/foo/bar/somefile.html')
+
     def test_missing_returns_404(self):
         pass
 


### PR DESCRIPTION
By default Flask uses a [string converter](http://flask.pocoo.org/docs/0.12/api/#url-route-registrations) for all `path`s under `<project>/latest/<path>` which does not accept any slashes. If one tries to link to a resource in a subdirectory this will result in a 404 (e.g., `project/latest/foo/bar/somefile.html` ==> 404). 

This PR enables the [path converter](http://flask.pocoo.org/docs/0.12/api/#url-route-registrations) so that all resources under `project/latest/*` will be processed and return a 302.