### PR TITLE
Adds travis support for py26-py36 + pypy(3)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: python
-python: 2.7
-env:
-  - TOX_ENV=py34
-  - TOX_ENV=py33
-  - TOX_ENV=py27
-  - TOX_ENV=py26
-  - TOX_ENV=pypy
+python:
+    - "2.6"
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "3.5"
+    - "3.6"
+    - "pypy"
+    - "pypy3"
 install:
-  - pip install tox
+  - pip install tox-travis
 script:
-  - tox -e $TOX_ENV
+  - tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, pypy
+envlist = py26, py27, py33, py34, py35, py36, pypy, pypy3
 
 [testenv]
 commands = nosetests
@@ -25,5 +25,22 @@ basepython = python3.4
 [testenv:py35]
 basepython = python3.5
 
+[testenv:py36]
+basepython = python3.6
+
 [testenv:pypy]
 basepython = pypy
+
+[testenv:pypy3]
+basepython = pypy3
+
+[travis]
+python =
+  2.6: py26
+  2.7: py27
+  3.3: py33
+  3.4: py34
+  3.5: py35
+  3.6: py36
+  pypy: pypy
+  pypy3: pypy3


### PR DESCRIPTION
It appears that travis builds have been broken for some time as a result of python2.6 not being found in the default python build container on travis. This PR addresses that issue and adds additional test coverage for `py35`, `py36`, and `pypy3`.

In order to achieve coverage, the travis build matrix is configured by removing the `env` component and using explicit `python` versions in conjunction with [`tox-travis`](http://tox-travis.readthedocs.io/en/stable/toxenv.html).