### PR TITLE
Fix unicode description issues

### DIFF
--- a/hostthedocs/filekeeper.py
+++ b/hostthedocs/filekeeper.py
@@ -4,6 +4,7 @@ import zipfile
 import tarfile
 import natsort
 
+from io import open
 from . import util
 
 
@@ -60,7 +61,7 @@ def _get_proj_dict(docfiles_dir, proj_dir, link_root):
     descr = DEFAULT_PROJECT_DESCRIPTION
     if 'description.txt' in allpaths:
         dpath = join_with_default_path('description.txt')
-        with open(dpath) as f:
+        with open(dpath, 'r', encoding='utf-8') as f:
             descr = f.read().strip()
     return {'name': proj_dir, 'versions': versions, 'description': descr}
 
@@ -98,7 +99,7 @@ def unpack_project(uploaded_file, proj_metadata, docfiles_dir):
     descr = proj_metadata.get('description', '')
     if len(descr) > 0:
         descrpath = os.path.join(projdir, 'description.txt')
-        with open(descrpath, 'w') as f:
+        with open(descrpath, 'w', encoding='utf-8') as f:
             f.write(descr)
 
     # This is insecure, we are only accepting things from trusted sources.

--- a/hostthedocs/filekeeper.py
+++ b/hostthedocs/filekeeper.py
@@ -4,7 +4,7 @@ import zipfile
 import tarfile
 import natsort
 
-from io import open
+from codecs import open
 from . import util
 
 


### PR DESCRIPTION
So currently, if you put unicode characters into the description field, you get this:
```
  File "/data/www/htfd/hostthedocs/filekeeper.py", line 102, in unpack_project
    f.write(descr)
UnicodeEncodeError: 'ascii' codec can't encode character '\u2122' in position 7: ordinal not in range(128)
```

This patch should fix it both on reading and writing.

Tests pass, but there's no specific test for a unicode name.  I started looking at the tests, but couldn't really make sense of them, so I figured I'd just give you the PR with the work as is.  I'll be happy to write some tests, but I'd probably need some help explaining them.