### PR TITLE
Disable 3.3 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: python
 python:
     - "2.6"
     - "2.7"
-    - "3.3"
+    # See https://github.com/rgalanakis/hostthedocs/pull/24 for details
+    # - "3.3"
     - "3.4"
     - "3.5"
     - "3.6"


### PR DESCRIPTION
It's apparently a known/new thing that tox and travis
with python 3.3 are having problems.
This disables 3.3, which should be relatively safe,
given this project is not making big changes,
and 3.3 is a smallish number of users.