### PR TITLE
util: use the uploaded werkzeug.FileStorage class directly

### DIFF
--- a/hostthedocs/__init__.py
+++ b/hostthedocs/__init__.py
@@ -18,7 +18,7 @@ def hmfd():
     if request.method == 'POST':
         if not request.files:
             return abort(400, 'Request is missing a zip/tar file.')
-        uploaded_file = util.UploadedFile.from_request(request)
+        uploaded_file = util.file_from_request(request)
         unpack_project(
             uploaded_file,
             request.form,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -22,10 +22,10 @@ class UtilityTests(unittest.TestCase):
             request = Request(builder.get_environ())
 
             # WHEN we process the request.
-            filestream = util.UploadedFile.from_request(request)
+            filestream = util.file_from_request(request)
 
             # THEN the file-stream should correspond to the provided file.
-            self.assertEqual(content, filestream.get_stream().read())
+            self.assertEqual(content, filestream.read())
 
     @raises(ValueError)
     def test_exception_thrown_if_request_contains_no_file(self):
@@ -34,4 +34,4 @@ class UtilityTests(unittest.TestCase):
         request = Request(builder.get_environ())
 
         # EXPECT an exception is thrown when we process the request.
-        util.UploadedFile.from_request(request)
+        util.file_from_request(request)


### PR DESCRIPTION
In newer versions of Werkzeug the uploaded file's stream is a
`SpooledTemporaryFile`. That class doesn't implement the .seekable method,
which is called by the Python `zipfile` library, and everything falls
over.

I experienced this error with Python 3.7.4 and package versions:
```
certifi==2019.6.16
Click==7.0
conf==0.4.1
Flask==1.1.1
itsdangerous==1.1.0
Jinja2==2.10.1
MarkupSafe==1.1.1
natsort==6.0.0
pipenv==2018.11.26
six==1.12.0
virtualenv==16.7.3
virtualenv-clone==0..5.3
Werkzeug==0.15.5
```

This patch avoids the issue by using the `FileStorage` class directly; as
of Werkzeug 0.15 it proxies this method correctly to whatever
object is backing the `SpooledTemporaryFile`.
Relevant GH issue: https://github.com/pallets/werkzeug/issues/1344

This may be the cause of #27.