### PR TITLE
/latest/: use an absolute redirect, update tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,10 @@
 language: python
 python:
-    - "2.6"
-    - "2.7"
     # See https://github.com/rgalanakis/hostthedocs/pull/24 for details
     # - "3.3"
     - "3.4"
     - "3.5"
     - "3.6"
-    - "pypy"
     - "pypy3"
 install:
   - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
     - "pypy3"
 install:
   - pip install tox-travis

--- a/hostthedocs/__init__.py
+++ b/hostthedocs/__init__.py
@@ -63,5 +63,4 @@ def latest(project, path):
         latestlink = '%s/%s' % (os.path.dirname(latestindex), path)
     else:
         latestlink = latestindex
-    # Should it be a 302 or something else?
-    return redirect(latestlink)
+    return redirect('/' + latestlink)

--- a/tests/test_hostthedocs.py
+++ b/tests/test_hostthedocs.py
@@ -51,12 +51,15 @@ class LatestTests(Base):
 
     def assert_redirect(self, path, code, location):
         resp = self.app.get(path)
-        self.assertEqual(resp.status_code, code)
+        if isinstance(code, list):
+            self.assertIn(resp.status_code, code)
+        else:
+            self.assertEqual(resp.status_code, code)
         gotloc = urlparse.urlsplit(dict(resp.headers)['Location']).path
         self.assertEqual(gotloc, location)
 
     def test_latest_noslash(self):
-        self.assert_redirect('/foo/latest', 301, '/foo/latest/')
+        self.assert_redirect('/foo/latest', [301, 308], '/foo/latest/')
 
     def test_latest_root(self):
             self.assert_redirect('/Project2/latest/', 302, '/linkroot/Project2/2.0.3/index.html')

--- a/tox.ini
+++ b/tox.ini
@@ -1,20 +1,11 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, py36, pypy, pypy3
+envlist = py33, py34, py35, py36, pypy3
 
 [testenv]
 commands = nosetests
 deps =
     nose
     mock
-
-[testenv:py26]
-basepython = python2.6
-deps =
-   {[testenv]deps}
-    unittest2
-
-[testenv:py27]
-basepython = python2.7
 
 [testenv:py33]
 basepython = python3.3
@@ -28,19 +19,13 @@ basepython = python3.5
 [testenv:py36]
 basepython = python3.6
 
-[testenv:pypy]
-basepython = pypy
-
 [testenv:pypy3]
 basepython = pypy3
 
 [travis]
 python =
-  2.6: py26
-  2.7: py27
   3.3: py33
   3.4: py34
   3.5: py35
   3.6: py36
-  pypy: pypy
   pypy3: pypy3

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py33, py34, py35, py36, pypy3
+envlist = py33, py34, py35, py36, py37, pypy3
 
 [testenv]
 commands = nosetests
@@ -7,25 +7,11 @@ deps =
     nose
     mock
 
-[testenv:py33]
-basepython = python3.3
-
-[testenv:py34]
-basepython = python3.4
-
-[testenv:py35]
-basepython = python3.5
-
-[testenv:py36]
-basepython = python3.6
-
-[testenv:pypy3]
-basepython = pypy3
-
 [travis]
 python =
   3.3: py33
   3.4: py34
   3.5: py35
   3.6: py36
+  3.7: py37
   pypy3: pypy3


### PR DESCRIPTION
This avoids an issue where the redirect is interpreted as a relative
URL.
This is caused by an update in one of the dependencies.
Resolves #28.

While I'm at it, updated one of the tests, because recent versions of
Werkzeug return a 308 for a permanent redirect. This is like a 301, but
preserves the request, including if it is a POST.

This fixes the tests on CI where it doesn't use the `Pipenv.lock`. 