### PR TITLE
Fix bootstrap3 clearfix issues with columns wrapping

### DIFF
--- a/hostthedocs/templates/index.html
+++ b/hostthedocs/templates/index.html
@@ -52,6 +52,11 @@
                     </div>
                 </div>
             </div>
+            {% if loop.index % 4 == 0 %}
+                {# Bootstrap 3, set up for 4 columns each row, but they can be different heights. To make them
+                   wrap properly we add a clearfix empty div at the end of each "row"#}
+                <div class="clearfix"></div>
+            {% endif %}
             {% endfor %}
 
         </div>


### PR DESCRIPTION
Add a clearfix empty div every 4 columns to allow the columns to flow properly even when the content varies in height
Fixes #32 