### PR TITLE
Update usage of gevent - upstream changed

### DIFF
--- a/hostthedocs/getconfig.py
+++ b/hostthedocs/getconfig.py
@@ -48,7 +48,7 @@ renderables = dict((k, v) for (k, v) in globals().items() if isinstance(v, six.s
 
 
 def serve_gevent(app):
-    from gevent.wsgi import WSGIServer
+    from gevent.pywsgi import WSGIServer
 
     http_server = WSGIServer((host, port), app)
     http_server.serve_forever()

--- a/hostthedocs/getconfig.py
+++ b/hostthedocs/getconfig.py
@@ -48,7 +48,10 @@ renderables = dict((k, v) for (k, v) in globals().items() if isinstance(v, six.s
 
 
 def serve_gevent(app):
-    from gevent.pywsgi import WSGIServer
+    try:
+        from gevent.pywsgi import WSGIServer
+    except ModuleNotFoundError:
+        from gevent.wsgi import WSGIServer
 
     http_server = WSGIServer((host, port), app)
     http_server.serve_forever()

--- a/hostthedocs/getconfig.py
+++ b/hostthedocs/getconfig.py
@@ -50,7 +50,7 @@ renderables = dict((k, v) for (k, v) in globals().items() if isinstance(v, six.s
 def serve_gevent(app):
     try:
         from gevent.pywsgi import WSGIServer
-    except ModuleNotFoundError:
+    except ImportError:
         from gevent.wsgi import WSGIServer
 
     http_server = WSGIServer((host, port), app)


### PR DESCRIPTION
At some point `gevent.wsgi` was moved to `gevent.pywsgi`, and we should update this call.  This isn't listed as a requirement, so it depends on whichever version of `gevent` you happen to have installed, but this is how the latest version works.