### PR TITLE
Add a navigation bar for moving between projects/versions

### DIFF
--- a/hostthedocs/__init__.py
+++ b/hostthedocs/__init__.py
@@ -39,18 +39,19 @@ def hmfd():
 
     return jsonify({'success': True})
 
-
 @app.route('/')
 def home():
     projects = parse_docfiles(getconfig.docfiles_dir, getconfig.docfiles_link_root)
     insert_link_to_latest(projects, '%(project)s/latest')
     return render_template('index.html', projects=projects, **getconfig.renderables)
 
-
 @app.route('/<project>/latest/')
 def latest_root(project):
     return latest(project, '')
 
+@app.route('/<project>/<version>/')
+def project_version_root(project, version):
+    return project_version_path(project, version, 'index.html')
 
 @app.route('/<project>/latest/<path:path>')
 def latest(project, path):
@@ -58,9 +59,29 @@ def latest(project, path):
     proj_for_name = dict((p['name'], p) for p in parsed_docfiles)
     if project not in proj_for_name:
         return 'Project %s not found' % project, 404
-    latestindex = proj_for_name[project]['versions'][-1]['link']
+    latestindex = proj_for_name[project]['versions'][-1]['normalized_link']
     if path:
         latestlink = '%s/%s' % (os.path.dirname(latestindex), path)
     else:
         latestlink = latestindex
     return redirect('/' + latestlink)
+
+@app.route('/<project>/<version>/<path:path>')
+def project_version_path(project, version, path):
+    parsed_docfiles = parse_docfiles(getconfig.docfiles_dir, getconfig.docfiles_link_root)
+    proj_for_name = dict((p['name'], p) for p in parsed_docfiles)
+    if project not in proj_for_name:
+        return 'Project %s not found' % project, 404
+    current_project = proj_for_name[project]
+    version_path = next((v['link'] for v in current_project['versions'] if v['version'] == version), None)
+    if version_path:
+        initial_page =  '%s/%s' % (os.path.dirname(version_path), path)
+        return render_template('viewer.html',
+            all_projects=proj_for_name,
+            current_project=current_project,
+            current_version=version,
+            initial_path=initial_page,
+            **getconfig.renderables
+        )
+    else:
+        return 'Version %s not found for project %s' % (version, project), 404

--- a/hostthedocs/filekeeper.py
+++ b/hostthedocs/filekeeper.py
@@ -42,7 +42,8 @@ def _get_proj_dict(docfiles_dir, proj_dir, link_root):
     - "versions": the list of the versions of the documentation. For each
       version, there is a :class:`dict` with:
       - "version": name of the version
-      - "link": the relative url of the version
+      - "link": the relative url of the version's actual files
+      - "normalized_link": the relative url of the version within the viewer
 
     If no valid versions have been found, returns ``None``.
     """
@@ -51,7 +52,11 @@ def _get_proj_dict(docfiles_dir, proj_dir, link_root):
 
     allpaths = os.listdir(join_with_default_path())
     versions = [
-        dict(version=p, link='%s/%s/%s/index.html' % (link_root, proj_dir, p))
+        dict(
+            version=p,
+            link='%s/%s/%s/index.html' % (link_root, proj_dir, p),
+            normalized_link='%s/%s/index.html' % (proj_dir, p)
+        )
         for p in allpaths if _is_valid_doc_version(join_with_default_path(p))
     ]
     if len(versions) == 0:

--- a/hostthedocs/templates/base.html
+++ b/hostthedocs/templates/base.html
@@ -7,7 +7,7 @@
     <title>{{ title }}</title>
 
     <!-- Bootstrap -->
-    <link href="static/bootstrap3/css/bootstrap.min.css" rel="stylesheet">
+    <link href="/static/bootstrap3/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
@@ -32,6 +32,7 @@
         }
 
     </style>
+
   </head>
   <body>
     {% block body %}{% endblock %}
@@ -39,6 +40,6 @@
     <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
     <!-- Include all compiled plugins (below), or include individual files as needed -->
-    <script src="static/bootstrap3/js/bootstrap.min.js"></script>
+    <script src="/static/bootstrap3/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/hostthedocs/templates/index.html
+++ b/hostthedocs/templates/index.html
@@ -43,7 +43,7 @@
                                 role="menu" aria-haspopup="true" aria-expanded="false">
                         {% for version in project.versions | reverse %}
                             {% if version.version != 'latest' %}
-                                <option value="{{ version.link }}">{{ version.version }}</option>
+                                <option value="{{ version.normalized_link }}">{{ version.version }}</option>
                             {% endif %}
                         {% endfor %}
                         </select>

--- a/hostthedocs/templates/viewer.html
+++ b/hostthedocs/templates/viewer.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{{ title }}</title>
+
+    <!-- Bootstrap -->
+    <link href="/static/bootstrap3/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+      <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
+      <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
+    <![endif]-->
+
+    <style type="text/css">
+        body {
+            height: 100vh;
+            overflow: hidden;
+        }
+
+        iframe#ifrm {
+            width: 100%;
+            height: calc(100% - 50px);
+            position: fixed;
+            top: 50px;
+        }
+
+        .container {
+            height: 50px;
+            position: relative;
+        }
+
+        #stuff {
+            position: absolute;
+            top: 50%;
+            transform: translateY(-50%);
+        }
+
+    </style>
+
+  </head>
+  <body>
+    <script type="text/javascript">
+        var projects = {{ all_projects | tojson }};
+
+        function currentpage()
+        {
+            var path = currentpath();
+            var root = window.location.origin;
+            return root + path;
+        }
+
+        function currentpath()
+        {
+            var direct_path = document.getElementById('ifrm').contentWindow.location.pathname;
+            return direct_path.replace(/^\/static\/docfiles/,'');
+        }
+
+        function iframe_changed()
+        {
+            window.history.pushState({},"",currentpath())
+            links = document.getElementById('ifrm').contentDocument.getElementsByTagName('a');
+            Array.from(links).filter(
+                el => el.origin != window.location.origin
+            ).forEach(
+                el => el.target = "_blank"
+            );
+        }
+
+        function gotodocs(obj)
+        {
+            var selectedValue = obj.options[obj.selectedIndex].value;
+            var el = document.getElementById('ifrm');
+            el.src = "../../" + selectedValue;
+        }
+
+        function projectselect(obj)
+        {
+            var selectedValue = obj.options[obj.selectedIndex].value;
+            var selectedProj = projects[selectedValue];
+            var el = document.getElementById('versions');
+            el.options.length = 0;
+            selectedProj.versions.filter(
+                version => version.version != 'latest'
+            ).reverse().forEach(
+                version => el.appendChild(new Option(version.version, version.link))
+            );
+
+
+            var ifrm = document.getElementById('ifrm');
+            var link = selectedProj.versions[selectedProj.versions.length - 1].link;
+            ifrm.src = '/' + link;
+        }
+    </script>
+
+    <div class="container">
+        <!-- /.row -->
+
+        <div id="stuff" class="row text-center">
+            <select name="projects" onchange="projectselect(this);"
+                    class="btn btn-success dropdown-toggle" type="button"
+                    role="menu" aria-haspopup="true" aria-expanded="false">
+            {% for name, details in all_projects.items() %}
+                {% if name == current_project.name %}
+                <option value="{{ name }}" selected>{{ name }}</option>
+                {% else %}
+                <option value="{{ name }}">{{ name }}</option>
+                {% endif %}
+            {% endfor %}
+            </select >
+
+            <select id="versions" name="versions" onchange="gotodocs(this);"
+                    class="btn btn-success dropdown-toggle" type="button"
+                    role="menu" aria-haspopup="true" aria-expanded="false">
+            {% for version in current_project.versions | reverse %}
+                {% if version.version == current_version %}
+                    <option value="{{ version.link }}" selected>{{ version.version }}</option>
+                {% elif version.version != 'latest' %}
+                    <option value="{{ version.link }}">{{ version.version }}</option>
+                {% endif %}
+            {% endfor %}
+            </select>
+        </div>
+        <!-- /.row -->
+
+    </div>
+
+    <iframe src="/{{ initial_path }}" id="ifrm" onLoad="iframe_changed()">
+    <!-- /.container -->
+
+    <!-- jQuery (necessary for Bootstrap's JavaScript plugins) -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+    <!-- Include all compiled plugins (below), or include individual files as needed -->
+    <script src="/static/bootstrap3/js/bootstrap.min.js"></script>
+  </body>
+</html>

--- a/tests/test_filekeeper.py
+++ b/tests/test_filekeeper.py
@@ -11,6 +11,7 @@ from hostthedocs import filekeeper as fk
 from hostthedocs import util
 from tests import DOCFILESDIR, THISDIR
 
+
 ZIPFILE = os.path.join(THISDIR, 'project.zip')
 TARFILE = os.path.join(THISDIR, 'project.tar')
 TARGZFILE = os.path.join(THISDIR, 'project.tar.gz')
@@ -22,6 +23,7 @@ def make_uploaded_file(filename=ZIPFILE):
     return werkzeug.datastructures.FileStorage(stream=stream, filename=basename)
 
 class TestParseDocfiles(unittest.TestCase):
+
     def test_parses(self):
         result = fk.parse_docfiles(DOCFILESDIR, 'static')
         ideal = [
@@ -30,8 +32,10 @@ class TestParseDocfiles(unittest.TestCase):
                 'description': 'Project description.',
                 'versions': [
                     {'version': '1.0.1',
+                     'normalized_link': 'project1/1.0.1/index.html',
                      'link': 'static/project1/1.0.1/index.html'},
                     {'version': '1.2.0',
+                     'normalized_link': 'project1/1.2.0/index.html',
                      'link': 'static/project1/1.2.0/index.html'}
                 ]
             },
@@ -41,6 +45,7 @@ class TestParseDocfiles(unittest.TestCase):
                 'description': fk.DEFAULT_PROJECT_DESCRIPTION,
                 'versions': [
                     {'version': '2.0.3',
+                     'normalized_link': 'Project2/2.0.3/index.html',
                      'link': 'static/Project2/2.0.3/index.html'},
                 ]
             },
@@ -49,6 +54,7 @@ class TestParseDocfiles(unittest.TestCase):
                 'description': fk.DEFAULT_PROJECT_DESCRIPTION,
                 'versions': [
                     {'version': '3.3.3',
+                     'normalized_link': 'project3/3.3.3/index.html',
                      'link': 'static/project3/3.3.3/index.html'},
                 ]
             }

--- a/tests/test_hostthedocs.py
+++ b/tests/test_hostthedocs.py
@@ -62,13 +62,13 @@ class LatestTests(Base):
         self.assert_redirect('/foo/latest', [301, 308], '/foo/latest/')
 
     def test_latest_root(self):
-            self.assert_redirect('/Project2/latest/', 302, '/linkroot/Project2/2.0.3/index.html')
+            self.assert_redirect('/Project2/latest/', 302, '/Project2/2.0.3/index.html')
 
     def test_latest_certainfile(self):
-            self.assert_redirect('/Project2/latest/somefile.html', 302, '/linkroot/Project2/2.0.3/somefile.html')
+            self.assert_redirect('/Project2/latest/somefile.html', 302, '/Project2/2.0.3/somefile.html')
 
     def test_latest_nestedfile(self):
-            self.assert_redirect('/Project2/latest/foo/bar/somefile.html', 302, '/linkroot/Project2/2.0.3/foo/bar/somefile.html')
+            self.assert_redirect('/Project2/latest/foo/bar/somefile.html', 302, '/Project2/2.0.3/foo/bar/somefile.html')
 
     def test_missing_returns_404(self):
         pass


### PR DESCRIPTION
This PR adds a new type of URL, `/<project>/<version>/`, to supplement the existing `/static/docfiles/<project>/<version>/` urls. The new URL format loads a 'viewport' page with a small navigation bar at the top, and the actual documentation loaded in a iframe below. This allows you to quickly navigate between projects and/or versions without having to go back to the index page. Links on the index page are also updated to take you to the viewport page rather than the raw docfiles (although the docfiles URLs still work exactly as they did before).

Some javascript is used to ensure that navigating around the documentation in the iframe still causes the URL in the address bar ot update appropriately, and, clicking an external link in the iframe loads in a new tab.