### PR TITLE
Pin alpine version to match Pipfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.6-alpine
 RUN pip install pipenv
 
 ADD ./Pipfile ./Pipfile


### PR DESCRIPTION
Currently running the docker image fails with the error below due to pulling down the latest version of Python from alpine. 

<pre>Traceback (most recent call last):
  File "//runserver.py", line 1, in <module>
    from hostthedocs import app, getconfig
  File "/hostthedocs/__init__.py", line 3, in <module>
    from flask import abort, Flask, jsonify, redirect, render_template, request
  File "/usr/local/lib/python3.10/site-packages/flask/__init__.py", line 14, in <module>
    from jinja2 import escape
  File "/usr/local/lib/python3.10/site-packages/jinja2/__init__.py", line 33, in <module>
    from jinja2.environment import Environment, Template
  File "/usr/local/lib/python3.10/site-packages/jinja2/environment.py", line 16, in <module>
    from jinja2.defaults import BLOCK_START_STRING, \
  File "/usr/local/lib/python3.10/site-packages/jinja2/defaults.py", line 32, in <module>
    from jinja2.tests import TESTS as DEFAULT_TESTS
  File "/usr/local/lib/python3.10/site-packages/jinja2/tests.py", line 13, in <module>
    from collections import Mapping
   ImportError: cannot import name 'Mapping' from 'collections' (/usr/local/lib/python3.10/collections/__init__.py)</pre>



If we pin to the version specified in the Pipfile, it resolves the problem.
